### PR TITLE
Move script calls to bsb into package.json instead of a shell file, so it works on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,15 @@
 {
     "name" : "bucklescript-have-tea", 
-    "version" : "0.1",
-    "dependencies" : {"bucklescript-tea" : "0.1.2" },
-    "peerDependencies" : { "bs-platform" : "^1.4.1"}
+    "version" : "0.1.0",
+    "scripts" : {
+        "clean" : "bsb -clean-world",
+        "prebuild" : "npm run clean",
+        "build" : "bsb -make-world",
+        "pretest" : "npm run build",
+        "test" : "echo 'Create test harness'",
+        "prewatch" : "npm run clean",
+        "watch" : "bsb -w"
+    },
+    "dependencies" : { "bucklescript-tea" : "^0.1.2" },
+    "peerDependencies" : { "bs-platform" : "^1.4.1" }
 }

--- a/test.sh
+++ b/test.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-bsb -clean-world
-bsb -make-world
-bsb -clean-world -make-world
-# bsb -clean-world -make-world -w
-# bsb -make-world -w


### PR DESCRIPTION
Move script calls to bsb into package.json instead of a shell file, so it works on windows as well as everywhere else.

Also, peerDependencies is not downloading bs-platform when it does not already exist, that should be fixed.